### PR TITLE
  Maintain AFP 3.x compliance while preserving file dates during GS/OS folder copies.

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -944,7 +944,8 @@ int setfilparams(struct vol *vol,
 		switch (bit) {
 		case FILPBIT_ATTR:
 			/* Preserve file dates during a GS/OS folder copy */
-			/* change_mdate = 1; */
+			if (afp_version >= 30) 
+				change_mdate = 1;
 			memcpy(&ashort, buf, sizeof(ashort));
 			buf += sizeof(ashort);
 			break;


### PR DESCRIPTION
Previous patch unintentionally broke compatibility with newer clients.

Patch tested against GS/OS System 6.0.1 client. "File Modified" date stamps are being preserved when files are copied to a server from a local drive. Without the patch, "File Modified" date stamp is changed to the current date.