### PR TITLE
Restore -ipaddr option in afpd.conf

### DIFF
--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -407,6 +407,8 @@ int afp_options_parseline(char *buf, struct afp_options *options)
 		options->uampath = opt;
 	if ((c = getoption(buf, "-uamlist")) && (opt = strdup(c)))
 		options->uamlist = opt;
+	if ((c = getoption(buf, "-ipaddr")) && (opt = strdup(c)))
+		options->ipaddr = opt;
 
 	/* FIXME CNID Cnid_srv is a server attribute */
 	if ((c = getoption(buf, "-cnidserver"))) {


### PR DESCRIPTION
During configuration on my multi-homed server, I noticed that netatalk seemed to be ignoring the documented `-ipaddr` option in afpd.conf and was just binding to the first-available address. After a bit of digging, it looks like #5 may have inadvertently removed the code that loaded the option. The rest of the code for applying this appears to be intact and afpd is showing the specified address on service startup after applying the attached change.