### PR TITLE
Remove unneeded server connection

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -120,17 +120,6 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         cupsSetPasswordCB(cups_passwd_cb);
 
-       /*
-        * Try to connect to the server...
-        */
-
-        if ((http = httpConnect(cupsServer(), ippPort())) == NULL)
-        {
-		LOG(log_error, logtype_papd, "Unable to connect to CUPS server %s - %s",
-                         cupsServer(), strerror(errno));
-                return (0);
-        }
-
 	/*
 	 * Try to connect to the requested printer...
 	 */
@@ -244,17 +233,6 @@ int cups_get_printer_status(struct printer *pr)
 	 */
 
 	cupsSetPasswordCB(cups_passwd_cb);
-
-	/*
-	 * Try to connect to the server...
-	 */
-
-	if ((http = httpConnect(cupsServer(), ippPort())) == NULL) {
-		LOG(log_error, logtype_papd,
-		    "Unable to connect to CUPS server %s - %s",
-		    cupsServer(), strerror(errno));
-		return (0);
-	}
 
 	/*
 	 * Try to connect to the requested printer...


### PR DESCRIPTION
We no longer need to create a connection to the server as the CUPS destination API is doing it for us now. This unneeded connection was causing CUPS to lock up with "Max Clients Reached" errors under certain situations.