### PR TITLE
Remove CUPS PPD API dependancy.

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -45,7 +45,6 @@
 
 #include <cups/ipp.h>
 #include <cups/cups.h>
-#include <cups/ppd.h>
 #include <cups/language.h>
 #include <atalk/unicode.h>
 #include <atalk/logger.h>
@@ -62,7 +61,6 @@
 /* Deal with post-1.7 deprecated httpConnect() */
 #define httpConnect(host, port)		httpConnect2(host, port, NULL, AF_UNSPEC, HTTP_ENCRYPTION_IF_REQUESTED, 1, 1000, NULL)
 
-/* XXX Also: cupsGetPPD() */
 
 static const char *cups_status_msg[] = {
 	"status: busy; info: \"%s\" is rejecting jobs; ",
@@ -205,8 +203,186 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
 const char *cups_get_printer_ppd(char *name)
 {
+	http_t		*http;		/* Connection to destination */
+	cups_dest_t	*dest = NULL;	/* Destination */
+	cups_dest_t 	*dests;		/* Destination List */
+	ipp_t           *request,       /* IPP Request */
+			*response;      /* IPP Response */
+	cups_lang_t	*language;      /* Default language */
+	char		uri[HTTP_MAX_URI]; /* printer-uri attribute */
+        static const char *pattrs[] =   /* Requested printer attributes */
+                        {
+                          "printer-make-and-model",
+                          "color-supported"
+                        };
+	ipp_attribute_t	*attr;
+  	cups_file_t	*fp;		/* PPD file */
+    	static char	buffer[1024];	/* I - Filename buffer */
+    	size_t		bufsize;	/* I - Size of filename buffer */
+  	char			make[256],	/* Make and model */
+				*model;
+
+
 	cupsSetPasswordCB(cups_passwd_cb);
-	return cupsGetPPD(name);
+
+	/*
+	We have to go this roundabout way to correctly get the make and model of DNS-SD discovered
+	printers. Otherwise we get the name of the CUPS temporary queue, which we don't want.
+	*/
+
+	int num_dests = cupsGetDests2(CUPS_HTTP_DEFAULT, &dests);
+	dest = cupsGetDest(name, NULL, num_dests, dests);
+	const char *make_model = cupsGetOption("printer-make-and-model", dest->num_options, dest->options);
+
+	if (!dest)
+	{
+		LOG(log_error, logtype_papd, "testdest: Unable to get destination \"%s\": %s\n", name, cupsLastErrorString());
+		return (0);
+	}
+
+	if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_NONE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
+	{
+		LOG(log_error, logtype_papd, "testdest: Unable to connect to destination \"%s\": %s\n", dest->name, cupsLastErrorString());
+		return (0);
+	}
+
+	sprintf(uri, "ipp://localhost/printers/%s", name);
+
+	/*
+	 * Build an IPP_GET_PRINTER_ATTRIBUTES request, which requires the
+	 * following attributes:
+	 *
+	 *    attributes-charset
+	 *    attributes-natural-language
+	 *    requested-attributes
+	 *    printer-uri
+	 */
+
+        request = ippNew();
+
+        ippSetOperation(request, IPP_GET_PRINTER_ATTRIBUTES);
+        ippSetRequestId(request, 1);
+
+	language = cupsLangDefault();
+
+	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_CHARSET,
+		     "attributes-charset", NULL,
+		     cupsLangEncoding(language));
+
+	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_LANGUAGE,
+		     "attributes-natural-language", NULL,
+		     language->language);
+
+	ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
+		      "requested-attributes",
+		      (sizeof(pattrs) / sizeof(pattrs[0])), NULL, pattrs);
+
+	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
+		     "printer-uri", NULL, uri);
+
+	/*
+	 * Do the request and get back a response...
+	 */
+
+        if ((response = cupsDoRequest(http, request, "/")) == NULL)
+        {
+                 LOG(log_error, logtype_papd,  "Unable to get printer attribs for %s - %s", name,
+                         ippErrorString(cupsLastError()));
+                httpClose(http);
+                return (0);
+        }
+
+        if (ippGetStatusCode(response) >= IPP_OK_CONFLICT)
+        {
+      		 LOG(log_error, logtype_papd,  "Unable to get printer attribs for %s - %s", name,
+                         ippErrorString(ippGetStatusCode(response)));
+                ippDelete(response);
+                httpClose(http);
+                return (0);
+        }
+
+	/*
+	* Range check input...
+	*/
+	
+	bufsize = sizeof(buffer);
+	if (buffer)
+		*buffer = '\0';
+
+	if (!buffer || bufsize < 1)
+	{
+		LOG(log_error, logtype_papd, "Check buffer failed!\n");
+		LOG(log_error, logtype_papd, strerror(EINVAL));
+		return (0);
+	}
+
+	if (!response)
+	{
+	LOG(log_error, logtype_papd, "No IPP attributes.\n");
+	return (0);
+	}
+
+	/*
+	* Open a temporary file for the PPD...
+	*/
+
+	if ((fp = cupsTempFile2(buffer, (int)bufsize)) == NULL)
+	{
+		LOG(log_error, logtype_papd, strerror(errno));
+		return (0);
+	}
+
+	/*
+	 * Standard stuff for PPD file...
+	 */
+
+	cupsFilePuts(fp, "*PPD-Adobe: \"4.3\"\n");
+	cupsFilePuts(fp, "*FormatVersion: \"4.3\"\n");
+	cupsFilePrintf(fp, "*FileVersion: \"%d.%d\"\n", CUPS_VERSION_MAJOR, CUPS_VERSION_MINOR);
+	cupsFilePuts(fp, "*LanguageVersion: English\n");
+	cupsFilePuts(fp, "*LanguageEncoding: ISOLatin1\n");
+	cupsFilePuts(fp, "*PSVersion: \"(3010.000) 0\"\n");
+	cupsFilePuts(fp, "*LanguageLevel: \"3\"\n");
+	cupsFilePuts(fp, "*FileSystem: False\n");
+	cupsFilePuts(fp, "*PCFileName: \"ippeve.ppd\"\n");
+
+	if ((dests != NULL))
+		strcpy(make, make_model);
+	else
+		strcpy(make, "Unknown Printer");
+
+	if (!strncasecmp(make, "Hewlett Packard ", 16) || !strncasecmp(make, "Hewlett-Packard ", 16))
+	{
+		model = make + 16;
+		strcpy(make, "HP");
+  	}
+	else if ((model = strchr(make, ' ')) != NULL)
+		*model++ = '\0';
+  	else
+		model = "Unknown";
+
+	cupsFilePrintf(fp, "*Manufacturer: \"%s\"\n", make);
+	cupsFilePrintf(fp, "*ModelName: \"%s\"\n", model);
+	cupsFilePrintf(fp, "*Product: \"(%s %s)\"\n", make, model);
+	cupsFilePrintf(fp, "*NickName: \"%s %s\"\n", make, model);
+	cupsFilePrintf(fp, "*ShortNickName: \"%s %s\"\n", make, model);
+
+ 	if ((attr = ippFindAttribute(response, "color-supported", IPP_TAG_BOOLEAN)) != NULL && ippGetBoolean(attr, 0))
+  		cupsFilePuts(fp, "*ColorDevice: True\n");
+	else
+		cupsFilePuts(fp, "*ColorDevice: False\n");
+	cupsFilePuts(fp, "*TTRasterizer: Type42\n");
+	cupsFilePuts(fp, "*?Resolution: 600dpi\n");
+
+	/*
+	Clean up.
+	*/
+	
+	httpClose(http);
+	ippDelete(response);
+	cupsFileClose(fp);
+	cupsFreeDests(num_dests,dests);
+	return (buffer);
 }
 
 int cups_get_printer_status(struct printer *pr)

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -52,10 +52,6 @@
 #define MAXCHOOSERLEN 31
 #define HTTP_MAX_URI 1024
 
-/* Deal with post-1.7 deprecated httpConnect() */
-#define httpConnect(host, port)		httpConnect2(host, port, NULL, AF_UNSPEC, HTTP_ENCRYPTION_IF_REQUESTED, 1, 1000, NULL)
-
-
 static const char *cups_status_msg[] = {
 	"status: busy; info: \"%s\" is rejecting jobs; ",
 	"status: idle; info: \"%s\" is stopped, accepting jobs ;",

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -209,16 +209,17 @@ const char *cups_get_printer_ppd(char *name)
   	cups_file_t	*fp;		/* PPD file */
     	static char	buffer[1024];	/* I - Filename buffer */
     	size_t		bufsize;	/* I - Size of filename buffer */
-  	char			make[256],	/* Make and model */
-				*model;
+  	char		make[256],	/* Make and model */
+			*model;
 
 
 	cupsSetPasswordCB(cups_passwd_cb);
 
 	/*
-	We have to go this roundabout way to correctly get the make and model of DNS-SD discovered
-	printers. Otherwise we get the name of the CUPS temporary queue, which we don't want.
-	*/
+	 *We have to go this roundabout way to correctly get the make and 
+	 *model of DNS-SD discovered printers. Otherwise we get the name of 
+	 *the CUPS temporary queue, which we don't want.
+	 */
 
 	int num_dests = cupsGetDests2(CUPS_HTTP_DEFAULT, &dests);
 	dest = cupsGetDest(name, NULL, num_dests, dests);
@@ -237,6 +238,10 @@ const char *cups_get_printer_ppd(char *name)
 		cupsFreeDests(num_dests,dests);
 		return (0);
 	}
+	
+	/*
+	 * Generate the printer URI...
+	 */
 
 	sprintf(uri, "ipp://localhost/printers/%s", name);
 
@@ -296,8 +301,8 @@ const char *cups_get_printer_ppd(char *name)
         }
 
 	/*
-	* Range check input...
-	*/
+	 * Range check input...
+	 */
 	
 	bufsize = sizeof(buffer);
 	if (buffer)
@@ -323,8 +328,8 @@ const char *cups_get_printer_ppd(char *name)
 	}
 
 	/*
-	* Open a temporary file for the PPD...
-	*/
+	 * Open a temporary file for the PPD...
+	 */
 
 	if ((fp = cupsTempFile2(buffer, (int)bufsize)) == NULL)
 	{
@@ -336,7 +341,7 @@ const char *cups_get_printer_ppd(char *name)
 	}
 
 	/*
-	 * Standard stuff for PPD file...
+	 * Write the header and some hard coded defaults for the PPD file...
 	 */
 
 	cupsFilePuts(fp, "*PPD-Adobe: \"4.3\"\n");
@@ -378,8 +383,8 @@ const char *cups_get_printer_ppd(char *name)
 	cupsFilePuts(fp, "*?Resolution: 600dpi\n");
 
 	/*
-	Clean up.
-	*/
+	 *Clean up.
+	 */
 	
 	httpClose(http);
 	ippDelete(response);

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -200,7 +200,7 @@ const char *cups_get_printer_ppd(char *name)
 			*response;      /* IPP Response */
 	cups_lang_t	*language;      /* Default language */
 	char		uri[HTTP_MAX_URI]; /* printer-uri attribute */
-        static const char *pattrs[] =   /* Requested printer attributes */
+        const char	*pattrs[] =   /* Requested printer attributes */
                         {
                           "printer-make-and-model",
                           "color-supported"

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -37,12 +37,6 @@
 
 #ifdef HAVE_CUPS
 
-/*
- * Do not error out on deprecation messages
- * -- darktable does this in their "src/common/cups_print.c"
- */
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <cups/ipp.h>
 #include <cups/cups.h>
 #include <cups/language.h>


### PR DESCRIPTION
Since the CUPS PPD API is going away in CUPS 3.0, we'll just generate our own.

This PR generates a very basic PPD from a printer's IPP attributes for papd to use to respond to printer information queries by the LaserWriter 8 driver.