### PR TITLE
[papd] Allow papd to return a printer resolution with LaserWriter 8 driver.

### DIFF
--- a/etc/papd/ppd.c
+++ b/etc/papd/ppd.c
@@ -40,6 +40,7 @@ struct ppd_feature ppd_features[] = {
 	{ "*ColorDevice", NULL },
 	{ "*FaxSupport", NULL },
 	{ "*TTRasterizer", NULL },
+        { "*Resolution", NULL },
 	{ NULL, NULL },
 };
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -381,6 +381,7 @@ const char *cups_get_printer_ppd(char *name)
 		cupsFilePuts(fp, "*ColorDevice: False\n");
 	cupsFilePuts(fp, "*TTRasterizer: Type42\n");
 	cupsFilePuts(fp, "*Resolution: 600dpi\n");
+	cupsFilePuts(fp, "*FaxSupport: None\n");
 
 	/*
 	 *Clean up.

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -380,7 +380,7 @@ const char *cups_get_printer_ppd(char *name)
 	else
 		cupsFilePuts(fp, "*ColorDevice: False\n");
 	cupsFilePuts(fp, "*TTRasterizer: Type42\n");
-	cupsFilePuts(fp, "*?Resolution: 600dpi\n");
+	cupsFilePuts(fp, "*Resolution: 600dpi\n");
 
 	/*
 	 *Clean up.

--- a/etc/papd/queries.c
+++ b/etc/papd/queries.c
@@ -499,6 +499,13 @@ int cq_feature(struct papfile *in, struct papfile *out)
 			while (*p == ' ') {
 				p++;
 			}
+			
+			/* handle the '?' at the beginning of LW8's Resolution Query */
+                        if (*p == '*' && *(p + 1) == '?')
+                        {
+                                p++;
+                                *p = '*';
+                        }
 
 			if ((pfe = ppd_feature(p, stop - p)) == NULL) {
 				if (comswitch(queries, cq_default) < 0) {


### PR DESCRIPTION
This PR fixes an issue with papd's handling of the LaserWriter 8's query of a printer's resolution. Technically this fix only works when using CUPS with papd since "real" printer PPD files usually store this value as "*DefaultResolution" and not "*Resolution". Since very few people use PostScript printers and RAW printer queues these days, this is not really an issue.